### PR TITLE
added unistd.h to include open and close support

### DIFF
--- a/telnetenable.c
+++ b/telnetenable.c
@@ -47,6 +47,7 @@
 #include <stdio.h>
 //#include <process.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "md5.h"
 #include "blowfish.h"


### PR DESCRIPTION
This fixes the gcc warnings on gcc 6.x and above:

`telnetenable.c: In function ‘main’:
telnetenable.c:188:3: warning: implicit declaration of function ‘write’ [-Wimplicit-function-declaration]
   write(sock, output_buf, datasize);
   ^~~~~
telnetenable.c:189:3: warning: implicit declaration of function ‘close’ [-Wimplicit-function-declaration]
   close(sock);
   ^~~~~`
